### PR TITLE
feat(#6): add expected_subject to verify_certificate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -407,8 +407,11 @@ def hkdf_derive(ikm: bytes, salt: bytes, info: bytes, length: int, extra: str = 
 def issue_certificate(subject: str, subject_pubkey_pem: bytes,
                       ca_priv_pem: bytes, ca_password: bytes,
                       validity_days: int = 365) -> dict: ...
-def verify_certificate(cert: dict, ca_pubkey_pem: bytes) -> bool: ...
-    # returns True iff signature valid AND not expired
+def verify_certificate(cert: dict, ca_pubkey_pem: bytes,
+                       expected_subject: str | None = None) -> bool: ...
+    # returns True iff signature valid AND not expired AND (if given)
+    # cert['subject'] == expected_subject. Default keeps every existing
+    # call site working.
 
 # common/protocol.py
 def pack_message(msg: dict) -> bytes: ...    # 4-byte length + JSON

--- a/scripts/check_frozen_signatures.py
+++ b/scripts/check_frozen_signatures.py
@@ -57,7 +57,7 @@ EXPECTED: list[tuple[str, str, str]] = [
      "(subject: str, subject_pubkey_pem: bytes, ca_priv_pem: bytes, "
      "ca_password: bytes, validity_days: int = 365) -> dict"),
     ("zerotrust.ca.cert", "verify_certificate",
-     "(cert: dict, ca_pubkey_pem: bytes) -> bool"),
+     "(cert: dict, ca_pubkey_pem: bytes, expected_subject: str | None = None) -> bool"),
 
     # common.protocol
     ("zerotrust.common.protocol", "pack_message", "(msg: dict) -> bytes"),

--- a/zerotrust/ca/cert.py
+++ b/zerotrust/ca/cert.py
@@ -20,7 +20,7 @@ Frozen signatures (per ARCHITECTURE.md §10.1):
 
     issue_certificate(subject, subject_pubkey_pem, ca_priv_pem, ca_password,
                       validity_days=365) -> dict
-    verify_certificate(cert, ca_pubkey_pem) -> bool
+    verify_certificate(cert, ca_pubkey_pem, expected_subject=None) -> bool
 """
 
 from __future__ import annotations
@@ -74,12 +74,25 @@ def issue_certificate(
     return cert
 
 
-def verify_certificate(cert: dict, ca_pubkey_pem: bytes) -> bool:
-    """Return True iff signature is valid AND the cert is currently in date.
+def verify_certificate(
+    cert: dict,
+    ca_pubkey_pem: bytes,
+    expected_subject: str | None = None,
+) -> bool:
+    """Return True iff signature is valid, cert is currently in date, AND
+    (if ``expected_subject`` is supplied) the cert's subject matches.
 
-    Returns False — never raises — on any malformed cert. Subject matching
-    against an expected identity is the caller's responsibility (see
-    ARCHITECTURE.md §3.4 step 3).
+    All three checks from ARCHITECTURE.md §3.4 are enforced here:
+      1. ``valid_until > now >= valid_from``
+      2. RSA-PSS signature verifies against ``ca_pubkey_pem``
+      3. (optional) ``cert["subject"] == expected_subject``
+
+    Returns False — never raises — on any malformed cert or check failure.
+
+    The subject comparison uses plain ``==`` deliberately: subjects are
+    public identifiers, not secrets, so there is no timing side-channel
+    concern (AI.md §1.13 mandates constant-time only for MACs / signatures
+    / nonces).
     """
     if not isinstance(cert, dict):
         return False
@@ -98,4 +111,8 @@ def verify_certificate(cert: dict, ca_pubkey_pem: bytes) -> bool:
     now = int(time.time())
     if not (cert["valid_from"] <= now <= cert["valid_until"]):
         return False
+
+    if expected_subject is not None and cert["subject"] != expected_subject:
+        return False
+
     return True

--- a/zerotrust/tests/test_ca.py
+++ b/zerotrust/tests/test_ca.py
@@ -46,6 +46,41 @@ def test_verify_rejects_tampered_subject(ca_keys, user_keys):
     assert cert_mod.verify_certificate(cert, ca_pub) is False
 
 
+# ---------------------------------------------------------------------------
+# Subject pinning (#6) — third check from ARCHITECTURE.md §3.4
+# ---------------------------------------------------------------------------
+
+def test_verify_with_matching_expected_subject(ca_keys, user_keys):
+    """When expected_subject matches the cert's subject, verification passes."""
+    ca_priv, ca_pub = ca_keys
+    _, user_pub = user_keys
+    cert = cert_mod.issue_certificate("alice", user_pub, ca_priv, PASSWORD)
+    assert cert_mod.verify_certificate(cert, ca_pub, expected_subject="alice") is True
+
+
+def test_verify_with_mismatched_expected_subject(ca_keys, user_keys):
+    """An otherwise-valid cert is rejected if the subject does not match.
+
+    This is the defence against identity-substitution: an attacker who replays
+    Alice's cert during a handshake where the server expected Bob must be
+    rejected before any session key is established.
+    """
+    ca_priv, ca_pub = ca_keys
+    _, user_pub = user_keys
+    cert = cert_mod.issue_certificate("alice", user_pub, ca_priv, PASSWORD)
+    assert cert_mod.verify_certificate(cert, ca_pub, expected_subject="mallory") is False
+
+
+def test_verify_default_subject_arg_keeps_old_behaviour(ca_keys, user_keys):
+    """Calling without expected_subject behaves exactly like before #6."""
+    ca_priv, ca_pub = ca_keys
+    _, user_pub = user_keys
+    cert = cert_mod.issue_certificate("alice", user_pub, ca_priv, PASSWORD)
+    # Two-arg form == three-arg form with expected_subject=None.
+    assert cert_mod.verify_certificate(cert, ca_pub) is True
+    assert cert_mod.verify_certificate(cert, ca_pub, expected_subject=None) is True
+
+
 def test_verify_rejects_tampered_pubkey(ca_keys, user_keys):
     ca_priv, ca_pub = ca_keys
     _, user_pub = user_keys


### PR DESCRIPTION
Implements ARCHITECTURE.md §3.4 step 3 — subject pinning.

- verify_certificate(cert, ca_pub, expected_subject=None) -> bool Default keeps every existing call site working (backwards-compatible).
- EXPECTED in check_frozen_signatures.py updated.
- ARCHITECTURE.md §10.1 frozen signature line updated.
- 3 new tests: match success, mismatch rejection, default-arg backwards-compat.

Closes #12