### PR TITLE
Fix #32: REVOKE_REQUEST - sender recall of pending uploads

### DIFF
--- a/zerotrust/client/cli.py
+++ b/zerotrust/client/cli.py
@@ -6,6 +6,7 @@ Usage::
     python -m zerotrust.client.cli --user alice upload <recipient> <file>   # M2 #12
     python -m zerotrust.client.cli --user alice list                        # M3 #15
     python -m zerotrust.client.cli --user alice download <file_id>          # M3 #17
+    python -m zerotrust.client.cli --user alice revoke <file_id>            # M3 #24 (bonus)
 
 This module implements the ``login`` subcommand (issue #15) and registers
 placeholder argparse subcommands for the upload/list/download verbs so
@@ -33,6 +34,7 @@ from collections.abc import Iterable
 
 from ..common.exceptions import AuthError, CryptoError, ProtocolError, ZeroTrustError
 from .download import list_pending
+from .revoke import revoke_file
 from .session import ClientAssetError, connected_session, login_session
 from .upload import upload_file
 
@@ -161,6 +163,44 @@ def cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_revoke(args: argparse.Namespace) -> int:
+    """Open a session and revoke ``args.file_id``.
+
+    Per the issue's acceptance criteria, a second revoke of the same
+    file is a no-op success on the server — so this command exits 0
+    whenever the server returns ``REVOKE_ACK``, regardless of whether
+    the status actually changed in this call.
+    """
+    password = _resolve_password(args.password)
+    try:
+        with connected_session(args.user, password) as session:
+            ack = revoke_file(session, args.file_id)
+    except ClientAssetError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except (ConnectionRefusedError, TimeoutError) as exc:
+        print(str(exc).lower(), file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(str(exc).lower(), file=sys.stderr)
+        return 1
+    except ProtocolError as exc:
+        # Server-side ERROR codes (NOT_FOUND, NOT_AUTHORIZED, AUTH_FAILED,
+        # ALREADY_DOWNLOADED, EXPIRED, STALE, REPLAY, MALFORMED) surface
+        # here. The exit code is non-zero so scripts can detect refusal.
+        print(str(exc), file=sys.stderr)
+        return 1
+    except (AuthError, CryptoError, ZeroTrustError):
+        print(AUTH_FAILED, file=sys.stderr)
+        return 1
+
+    print(
+        f"Revoked file_id={ack.get('file_id', args.file_id)}; "
+        f"status={ack.get('status', 'revoked')}"
+    )
+    return 0
+
+
 def cmd_download(args: argparse.Namespace) -> int:
     """Open a session and download ``args.file_id``."""
     password = _resolve_password(args.password)
@@ -230,6 +270,13 @@ def build_parser() -> argparse.ArgumentParser:
     download = sub.add_parser("download", help="Download a file by file_id (M3 #17).")
     download.add_argument("file_id", help="Identifier of the file to download.")
     download.set_defaults(func=cmd_download)
+
+    revoke = sub.add_parser(
+        "revoke",
+        help="Revoke a still-pending upload by file_id (M3 #24 bonus).",
+    )
+    revoke.add_argument("file_id", help="Identifier of the file to revoke.")
+    revoke.set_defaults(func=cmd_revoke)
 
     return parser
 

--- a/zerotrust/client/revoke.py
+++ b/zerotrust/client/revoke.py
@@ -1,0 +1,93 @@
+"""Client revoke flow (issue #24 / bonus).
+
+Symmetric to :func:`zerotrust.client.upload.upload_file` — builds the
+canonical revoke struct, signs it with the user's RSA-PSS key, sends
+``REVOKE_REQUEST``, and surfaces the server's ``REVOKE_ACK`` payload
+(or raises :class:`ProtocolError` for any ``ERROR`` reply).
+
+The signature is over the frozen canonical struct from
+:mod:`zerotrust.common.revoke` — never an inline ``json.dumps`` (that's
+one of the pitfalls explicitly called out in the issue body).
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from typing import Any
+
+from ..common.exceptions import ProtocolError
+from ..common.protocol import (
+    make_envelope,
+    recv_message,
+    send_message,
+    validate_envelope,
+)
+from ..common.revoke import sign_revoke_struct
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def revoke_file(session: dict[str, Any], file_id: str) -> dict[str, Any]:
+    """Send a signed ``REVOKE_REQUEST`` for *file_id* and return the ACK payload.
+
+    Args:
+        session: Live session dict from
+            :func:`zerotrust.client.session.connected_session`.
+        file_id: UUID-shaped identifier of the file to revoke.
+
+    Returns:
+        The server's ``REVOKE_ACK`` payload, e.g. ``{"file_id": ...,
+        "status": "revoked"}``. The acceptance criteria call out that a
+        second revoke of the same file is idempotent — the server still
+        replies with a ``REVOKE_ACK`` so this function still returns the
+        payload rather than raising.
+
+    Raises:
+        ProtocolError: malformed reply or any server-side ``ERROR``
+            envelope (``NOT_FOUND``, ``NOT_AUTHORIZED``, ``AUTH_FAILED``,
+            ``ALREADY_DOWNLOADED``, ``EXPIRED``, ``STALE`` / ``REPLAY``,
+            ``MALFORMED``).
+    """
+    if not isinstance(file_id, str) or not file_id:
+        raise ProtocolError("file_id must be a non-empty string")
+
+    sock = session.get("sock")
+    sender = session.get("username")
+    sender_priv = session.get("client_priv_pem")
+    sender_password = session.get("client_password")
+    if sock is None or not isinstance(sender, str):
+        raise ProtocolError("live client session is required")
+    if not isinstance(sender_priv, (bytes, bytearray)):
+        raise ProtocolError("sender private key missing from session")
+    if not isinstance(sender_password, (bytes, bytearray)):
+        raise ProtocolError("sender password missing from session")
+
+    timestamp = int(time.time())
+    signature = sign_revoke_struct(
+        bytes(sender_priv),
+        bytes(sender_password),
+        sender=sender,
+        file_id=file_id,
+        timestamp=timestamp,
+    )
+
+    payload = {
+        "file_id": file_id,
+        "timestamp": timestamp,
+        "signature": _b64(signature),
+    }
+    send_message(sock, make_envelope("REVOKE_REQUEST", payload))
+
+    reply = validate_envelope(recv_message(sock))
+    if reply["type"] == "ERROR":
+        code = reply["payload"].get("code", "ERROR")
+        raise ProtocolError(str(code))
+    if reply["type"] != "REVOKE_ACK":
+        raise ProtocolError(f"expected REVOKE_ACK, got {reply['type']!r}")
+    return reply["payload"]
+
+
+__all__ = ["revoke_file"]

--- a/zerotrust/common/protocol.py
+++ b/zerotrust/common/protocol.py
@@ -121,6 +121,7 @@ MESSAGE_TYPES = frozenset({
     "DOWNLOAD_RESPONSE",
     "DOWNLOAD_ACK",
     "REVOKE_REQUEST",
+    "REVOKE_ACK",
     "ERROR",
 })
 

--- a/zerotrust/common/revoke.py
+++ b/zerotrust/common/revoke.py
@@ -1,0 +1,115 @@
+"""Sender revocation signatures (issue #24 / bonus).
+
+The bonus feature lets the sender recall a still-pending upload before
+the recipient downloads it. To prove that the revoke really came from
+the original sender — not from a curious server or an attacker who got
+hold of a session — the request carries an RSA-PSS signature over a
+frozen canonical struct:
+
+    {"action": "revoke", "file_id": ..., "sender": ..., "timestamp": ...}
+
+ARCHITECTURE.md §11 lists revocation as a bonus feature, and §8 lists
+the file-lifecycle states (pending → revoked). The signature MUST be
+verified server-side per the issue's pitfalls — having an authenticated
+session is *not* enough; the per-request signature proves the request
+itself wasn't forged inside an authenticated session by a buggy client.
+
+Mirrors :mod:`zerotrust.common.origin` so upload (#19) and revoke (#24)
+keep the same shape and so all canonical-JSON construction lives behind
+the same chokepoint (no inline ``json.dumps`` at call sites — that's the
+pitfall called out in the issue).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .canonical import canonical_json
+from .crypto_primitives import rsa_sign, rsa_verify
+from .exceptions import CryptoError
+
+REVOKE_ACTION = "revoke"
+
+
+def _build_canonical(
+    *,
+    sender: str,
+    file_id: str,
+    timestamp: int,
+) -> bytes:
+    """Build the frozen revoke canonical struct.
+
+    Field order in the dict literal is irrelevant — ``canonical_json``
+    sorts the keys — but the field NAMES are part of the wire contract
+    and must not be renamed without bumping ARCHITECTURE.md §8 and every
+    call site at once.
+
+    The ``action`` field exists so a future "ack"-style signed request
+    over the same envelope shape cannot be replayed as a revoke (and
+    vice-versa): the signed bytes always start with ``"action":"revoke"``.
+    """
+    return canonical_json(
+        {
+            "action": REVOKE_ACTION,
+            "file_id": file_id,
+            "sender": sender,
+            "timestamp": timestamp,
+        }
+    )
+
+
+def sign_revoke_struct(
+    sender_priv: bytes,
+    password: bytes,
+    *,
+    sender: str,
+    file_id: str,
+    timestamp: int,
+) -> bytes:
+    """Return an RSA-PSS signature over the frozen revoke canonical struct.
+
+    All binding fields are keyword-only — a positional reorder of
+    ``sender`` / ``file_id`` would otherwise silently produce a valid-
+    but-wrong signature, mirroring the same defence in
+    :func:`zerotrust.common.origin.sign_origin_struct`.
+    """
+    canonical = _build_canonical(
+        sender=sender, file_id=file_id, timestamp=timestamp,
+    )
+    return rsa_sign(sender_priv, password, canonical)
+
+
+def verify_revoke_struct(
+    sender_cert: dict[str, Any],
+    signature: bytes,
+    *,
+    sender: str,
+    file_id: str,
+    timestamp: int,
+) -> bool:
+    """Return ``True`` iff *signature* matches the frozen revoke struct.
+
+    Fail-closed: any malformed cert (missing key, non-string PEM), any
+    Unicode error, or any signature failure returns ``False`` rather
+    than raising — so callers can drop the request via the standard
+    fail-closed branch without a special-case ``try``.
+
+    Per the issue's pitfall list, the caller is responsible for verifying
+    ``sender_cert`` against the CA *first*; this function trusts the
+    embedded public key.
+    """
+    try:
+        public_key_pem = sender_cert["public_key_pem"].encode("ascii")
+        canonical = _build_canonical(
+            sender=sender, file_id=file_id, timestamp=timestamp,
+        )
+        return rsa_verify(public_key_pem, canonical, signature)
+    except (AttributeError, KeyError, TypeError, UnicodeEncodeError, CryptoError):
+        return False
+
+
+__all__ = [
+    "REVOKE_ACTION",
+    "sign_revoke_struct",
+    "verify_revoke_struct",
+]

--- a/zerotrust/server/handler.py
+++ b/zerotrust/server/handler.py
@@ -45,6 +45,7 @@ from ..common.protocol import (
     send_message,
     validate_envelope,
 )
+from ..common.revoke import verify_revoke_struct
 from . import replay, store
 from .handshake import perform_server_handshake
 from .storage_layout import (
@@ -660,6 +661,248 @@ def _handle_download_request(
     )
 
 # ---------------------------------------------------------------------------
+# REVOKE_REQUEST (issue #24 / bonus)
+# ---------------------------------------------------------------------------
+
+# Status values that are "terminal" with respect to revocation.  Mapped to
+# the wire error code the server returns when the sender tries to revoke a
+# row in that state.  ``revoked`` is intentionally NOT in here — the
+# acceptance criteria require the second revoke to be a no-op success
+# (idempotent), not an error.
+_REVOKE_TERMINAL_STATES = {
+    "downloaded": "ALREADY_DOWNLOADED",
+    "expired": "EXPIRED",
+}
+
+
+def _handle_revoke_request(
+    sock,
+    envelope: dict[str, Any],
+    db_conn,
+    session: dict[str, Any],
+    ca_pubkey_pem: bytes,
+) -> None:
+    """Process a sender's ``REVOKE_REQUEST`` envelope.
+
+    The 7-step flow comes directly from the issue body:
+
+    1. Envelope replay/freshness check (same primitive as upload).
+    2. Look up the file row → ``NOT_FOUND`` if missing.
+    3. Ownership: the *handshake-proven* peer subject must equal
+       ``row["sender_id"]``.  The payload may not override this — that's
+       the first pitfall in the issue.  ``NOT_AUTHORIZED`` otherwise.
+    4. Re-verify the sender certificate against the CA and verify the
+       per-request RSA-PSS signature over the frozen revoke canonical
+       struct.  ``AUTH_FAILED`` on any failure — having an authenticated
+       session is *not* enough on its own (issue pitfall).
+    5. State machine: only ``pending`` rows can flip to ``revoked``.
+       ``downloaded`` → ``ALREADY_DOWNLOADED``; ``expired`` → ``EXPIRED``;
+       ``revoked`` → idempotent ``REVOKE_ACK`` no-op success.
+    6. ``store.mark_status(...)`` — never roll our own SQL update.
+    7. Reply ``REVOKE_ACK {file_id, status}``.
+
+    The ciphertext blob is deliberately left on disk; the cleanup thread
+    (issue #27) is the only piece allowed to touch the filesystem.
+    Disk-touching here would create atomicity bugs (issue pitfall).
+    """
+    request_id = _request_id(envelope)
+    sender = session.get("peer_subject")
+    sender_fp = _cert_fp(session.get("peer_cert"))
+
+    # 1. Replay protection (cheap — do FIRST to avoid crypto-cost DoS).
+    try:
+        envelope_nonce = base64.b64decode(envelope["nonce"], validate=True)
+    except Exception:  # noqa: BLE001
+        audit_error(
+            logger,
+            "revoke_reject",
+            reason="malformed_envelope_nonce",
+            sender=sender,
+            request_id=request_id,
+        )
+        _send_error(sock, "MALFORMED")
+        return
+    envelope_nonce_fp = fingerprint(envelope_nonce)
+    if not replay.check_and_record(db_conn, envelope_nonce, envelope["timestamp"]):
+        audit_warning(
+            logger,
+            "replay_reject",
+            scope="revoke",
+            sender=sender,
+            request_id=request_id,
+            nonce_fp=envelope_nonce_fp,
+            envelope_timestamp=envelope.get("timestamp"),
+        )
+        _send_error(sock, "STALE")
+        return
+
+    # Sanity-check payload shape before any DB / crypto work.
+    payload = envelope["payload"]
+    try:
+        file_id = payload["file_id"]
+        ts_field = payload["timestamp"]
+        if not isinstance(file_id, str) or str(uuid.UUID(file_id)) != file_id:
+            raise ProtocolError("invalid file_id")
+        if not isinstance(ts_field, int):
+            raise ProtocolError("timestamp must be int")
+        signature = _decode_b64_field(payload, "signature")
+    except (KeyError, ValueError, ProtocolError) as exc:
+        audit_warning(
+            logger,
+            "revoke_reject",
+            reason="malformed_payload",
+            sender=sender,
+            request_id=request_id,
+            err_type=type(exc).__name__,
+        )
+        _send_error(sock, "MALFORMED")
+        return
+
+    # 2. Look up the file row.
+    file_record = store.get_file(db_conn, file_id)
+    if file_record is None:
+        audit_warning(
+            logger,
+            "revoke_reject",
+            reason="file_not_in_db",
+            file_id=file_id,
+            sender=sender,
+            client_code="NOT_FOUND",
+            request_id=request_id,
+        )
+        _send_error(sock, "NOT_FOUND")
+        return
+
+    # 3. Ownership — the handshake identity is the ONLY truth source.
+    #    Per the issue pitfall, payload["sender"] must NEVER be used here.
+    if file_record["sender_id"] != sender:
+        audit_warning(
+            logger,
+            "unauthorized_revoke",
+            reason="sender_mismatch",
+            file_id=file_id,
+            requester=sender,
+            expected=file_record["sender_id"],
+            client_code="NOT_AUTHORIZED",
+            request_id=request_id,
+        )
+        _send_error(sock, "NOT_AUTHORIZED")
+        return
+
+    # 4. Re-verify the sender cert and the per-request signature.  We
+    #    rebuild the canonical struct from server-controlled values (the
+    #    handshake-proven sender, the row's file_id, the payload
+    #    timestamp the client signed) so a tampered payload field is
+    #    caught by the signature check.
+    if not verify_certificate(session["peer_cert"], ca_pubkey_pem, expected_subject=sender):
+        audit_warning(
+            logger,
+            "auth_fail",
+            scope="revoke",
+            reason="sender_cert_invalid",
+            sender=sender,
+            fp=sender_fp,
+            request_id=request_id,
+        )
+        _send_error(sock, "AUTH_FAILED")
+        return
+
+    if not verify_revoke_struct(
+        session["peer_cert"],
+        signature,
+        sender=sender,
+        file_id=file_id,
+        timestamp=ts_field,
+    ):
+        audit_error(
+            logger,
+            "revoke_sig_fail",
+            sender=sender,
+            file_id=file_id,
+            sender_fp=sender_fp,
+            sig_prefix=hashlib.sha256(signature).hexdigest()[:8],
+            request_id=request_id,
+        )
+        _send_error(sock, "AUTH_FAILED")
+        return
+
+    # 5. State machine.
+    current_status = file_record["status"]
+    if current_status == "revoked":
+        # Idempotent no-op success.  Acceptance criterion:
+        # "no log noise" — log at DEBUG so the audit stream stays clean
+        # on retries while still leaving a breadcrumb for operators.
+        logger.debug(
+            "revoke_idempotent file=%s sender=%s request_id=%s",
+            file_id, sender, request_id,
+        )
+        send_message(sock, make_envelope("REVOKE_ACK", {
+            "file_id": file_id,
+            "status": "revoked",
+        }))
+        return
+
+    if current_status in _REVOKE_TERMINAL_STATES:
+        terminal_code = _REVOKE_TERMINAL_STATES[current_status]
+        audit_warning(
+            logger,
+            "revoke_reject",
+            reason=f"status_{current_status}",
+            file_id=file_id,
+            sender=sender,
+            client_code=terminal_code,
+            request_id=request_id,
+        )
+        _send_error(sock, terminal_code)
+        return
+
+    if current_status != "pending":
+        # Unknown status — should never happen, but fail-closed.
+        audit_error(
+            logger,
+            "revoke_reject",
+            reason="unknown_status",
+            status=current_status,
+            file_id=file_id,
+            sender=sender,
+            client_code="INTERNAL_ERROR",
+            request_id=request_id,
+        )
+        _send_error(sock, "INTERNAL_ERROR")
+        return
+
+    # 6. Flip the row.  We delegate to store.mark_status — never roll our
+    #    own UPDATE here (issue pitfall).
+    try:
+        store.mark_status(db_conn, file_id, "revoked")
+    except (sqlite3.Error, ValueError) as exc:
+        audit_error(
+            logger,
+            "revoke_internal_error",
+            file_id=file_id,
+            sender=sender,
+            err_type=type(exc).__name__,
+            request_id=request_id,
+        )
+        _send_error(sock, "INTERNAL_ERROR")
+        return
+
+    # 7. ACK.
+    send_message(sock, make_envelope("REVOKE_ACK", {
+        "file_id": file_id,
+        "status": "revoked",
+    }))
+    audit_info(
+        logger,
+        "revoke_accept",
+        file_id=file_id,
+        sender=sender,
+        sender_fp=sender_fp,
+        request_id=request_id,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Connection driver
 # ---------------------------------------------------------------------------
 
@@ -723,6 +966,14 @@ def serve_connection(sock, addr, server_state):
                     db_conn,
                     session,
                     server_state,
+                )
+            elif msg_type == "REVOKE_REQUEST":
+                _handle_revoke_request(
+                    sock,
+                    envelope,
+                    db_conn,
+                    session,
+                    ca_pubkey_pem,
                 )
             else:
                 audit_warning(

--- a/zerotrust/tests/test_revocation.py
+++ b/zerotrust/tests/test_revocation.py
@@ -1,0 +1,561 @@
+"""Server-side REVOKE_REQUEST regression suite (issue #24 / bonus).
+
+Each bullet from the issue's acceptance-criteria + required-tests
+sections gets its own test, plus a few defence-in-depth tests for the
+pitfalls (payload-sender override attempt, blob-must-stay-on-disk).
+
+We drive the server through a real ``ThreadingTCPServer`` thread and
+hand-build envelopes for the negative cases so each test can corrupt
+exactly one thing.  The happy path goes through the real
+:func:`zerotrust.client.revoke.revoke_file` helper so the helper itself
+gets covered by integration.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import socket
+import sqlite3
+import threading
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from zerotrust.ca import cert as cert_mod
+from zerotrust.client.handshake import perform_client_handshake
+from zerotrust.client.revoke import revoke_file
+from zerotrust.common import crypto_primitives as cp
+from zerotrust.common.exceptions import ProtocolError
+from zerotrust.common.file_crypto import encrypt_file_blob
+from zerotrust.common.key_wrap import wrap_aes_key_for
+from zerotrust.common.origin import sign_origin_struct
+from zerotrust.common.protocol import (
+    make_envelope,
+    recv_message,
+    send_message,
+    validate_envelope,
+)
+from zerotrust.common.revoke import sign_revoke_struct
+from zerotrust.server.main import ZeroTrustRequestHandler, ZeroTrustServer
+
+CA_PASSWORD = b"ca-revoke-pw"
+SERVER_PASSWORD = b"server-revoke-pw"
+ALICE_PASSWORD = b"alice-revoke-pw"
+BOB_PASSWORD = b"bob-revoke-pw"
+MALLORY_PASSWORD = b"mallory-revoke-pw"
+
+
+# ---------------------------------------------------------------------------
+# Fixture environment — three CA-signed users (alice sender, bob recipient,
+# mallory attacker) + server + DB on disk.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Env:
+    tmp: Path
+    storage: Path
+    pubkeys: Path
+    files: Path
+    ca_priv: bytes
+    ca_pub: bytes
+    ca_cert: dict
+    server_priv: bytes
+    server_cert: dict
+    alice_priv: bytes
+    alice_cert: dict
+    bob_priv: bytes
+    bob_cert: dict
+    mallory_priv: bytes
+    mallory_cert: dict
+    db_path: Path
+
+
+def _build_env(tmp_path: Path) -> _Env:
+    storage = tmp_path / "server_storage"
+    pubkeys = storage / "pubkeys"
+    files = storage / "files"
+    storage.mkdir()
+    pubkeys.mkdir()
+    files.mkdir()
+
+    ca_priv, ca_pub = cp.generate_rsa_keypair(CA_PASSWORD)
+    ca_cert = cert_mod.issue_certificate(
+        "ZeroTrustCA", ca_pub, ca_priv, CA_PASSWORD, validity_days=3650,
+    )
+    server_priv, server_pub = cp.generate_rsa_keypair(SERVER_PASSWORD)
+    server_cert = cert_mod.issue_certificate(
+        "zerotrust-server", server_pub, ca_priv, CA_PASSWORD,
+    )
+    alice_priv, alice_pub = cp.generate_rsa_keypair(ALICE_PASSWORD)
+    alice_cert = cert_mod.issue_certificate(
+        "alice", alice_pub, ca_priv, CA_PASSWORD,
+    )
+    bob_priv, bob_pub = cp.generate_rsa_keypair(BOB_PASSWORD)
+    bob_cert = cert_mod.issue_certificate(
+        "bob", bob_pub, ca_priv, CA_PASSWORD,
+    )
+    mallory_priv, mallory_pub = cp.generate_rsa_keypair(MALLORY_PASSWORD)
+    mallory_cert = cert_mod.issue_certificate(
+        "mallory", mallory_pub, ca_priv, CA_PASSWORD,
+    )
+
+    (pubkeys / "alice.json").write_text(json.dumps(alice_cert))
+    (pubkeys / "bob.json").write_text(json.dumps(bob_cert))
+
+    return _Env(
+        tmp=tmp_path,
+        storage=storage,
+        pubkeys=pubkeys,
+        files=files,
+        ca_priv=ca_priv, ca_pub=ca_pub, ca_cert=ca_cert,
+        server_priv=server_priv, server_cert=server_cert,
+        alice_priv=alice_priv, alice_cert=alice_cert,
+        bob_priv=bob_priv, bob_cert=bob_cert,
+        mallory_priv=mallory_priv, mallory_cert=mallory_cert,
+        db_path=storage / "metadata.db",
+    )
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> _Env:
+    return _build_env(tmp_path)
+
+
+def _server_state(env: _Env) -> dict[str, Any]:
+    return {
+        "db_path": str(env.db_path),
+        "ca_pubkey_pem": env.ca_pub,
+        "server_cert": env.server_cert,
+        "server_priv_pem": env.server_priv,
+        "server_password": SERVER_PASSWORD,
+        "storage_dir": str(env.storage),
+        "pubkeys_dir": str(env.pubkeys),
+        "files_dir": str(env.files),
+    }
+
+
+@contextmanager
+def _running_server(env: _Env) -> Iterator[int]:
+    server = ZeroTrustServer(
+        ("127.0.0.1", 0), ZeroTrustRequestHandler, _server_state(env),
+    )
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@contextmanager
+def _session_socket(
+    env: _Env,
+    port: int,
+    *,
+    user: str = "alice",
+) -> Iterator[dict[str, Any]]:
+    """Open a TCP socket, run the handshake as *user*, yield a session dict
+    compatible with the client helpers (so we can call
+    :func:`revoke_file` against the real server)."""
+    creds = {
+        "alice": (env.alice_cert, env.alice_priv, ALICE_PASSWORD),
+        "bob": (env.bob_cert, env.bob_priv, BOB_PASSWORD),
+        "mallory": (env.mallory_cert, env.mallory_priv, MALLORY_PASSWORD),
+    }
+    client_cert, client_priv, client_pw = creds[user]
+
+    sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+    try:
+        state = perform_client_handshake(
+            sock=sock,
+            client_cert=client_cert,
+            client_priv_pem=client_priv,
+            client_password=client_pw,
+            ca_pubkey_pem=env.ca_pub,
+            expected_server_subject="zerotrust-server",
+        )
+        live = dict(state)
+        live.update({
+            "sock": sock,
+            "username": user,
+            "client_cert": client_cert,
+            "client_priv_pem": client_priv,
+            "client_password": client_pw,
+            "ca_pubkey_pem": env.ca_pub,
+        })
+        yield live
+    finally:
+        sock.close()
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _upload_one(
+    env: _Env,
+    port: int,
+    *,
+    sender_user: str = "alice",
+    recipient: str = "bob",
+    plaintext: bytes = b"hello bob",
+) -> str:
+    """Push one valid upload through the live server and return file_id."""
+    creds = {
+        "alice": (env.alice_priv, ALICE_PASSWORD, env.alice_cert),
+    }
+    sender_priv, sender_pw, _sender_cert = creds[sender_user]
+    recipient_cert = env.bob_cert if recipient == "bob" else env.alice_cert
+
+    file_id = str(uuid.uuid4())
+    nonce, ciphertext, aes_key = encrypt_file_blob(
+        plaintext, file_id, sender=sender_user, recipient=recipient,
+    )
+    wrapped_key = wrap_aes_key_for(recipient_cert, aes_key)
+    ciphertext_sha256 = hashlib.sha256(ciphertext).hexdigest()
+    wrapped_key_sha256 = hashlib.sha256(wrapped_key).hexdigest()
+    ts = int(time.time())
+    expiration = ts + 3600
+    signature = sign_origin_struct(
+        sender_priv, sender_pw,
+        sender=sender_user, recipient=recipient, file_id=file_id,
+        ciphertext_sha256=ciphertext_sha256,
+        wrapped_key_sha256=wrapped_key_sha256,
+        timestamp=ts, expiration=expiration,
+    )
+    payload = {
+        "file_id": file_id,
+        "recipient": recipient,
+        "ciphertext": _b64(ciphertext),
+        "nonce": _b64(nonce),
+        "wrapped_key": _b64(wrapped_key),
+        "signature": _b64(signature),
+        "timestamp": ts,
+        "expiration": expiration,
+    }
+    with _session_socket(env, port, user=sender_user) as session:
+        send_message(session["sock"], make_envelope("UPLOAD_REQUEST", payload))
+        reply = validate_envelope(recv_message(session["sock"]))
+    assert reply["type"] == "UPLOAD_ACK", reply
+    return file_id
+
+
+def _row_status(env: _Env, file_id: str) -> str | None:
+    conn = sqlite3.connect(str(env.db_path))
+    try:
+        row = conn.execute(
+            "SELECT status FROM files WHERE file_id = ?", (file_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return row[0] if row else None
+
+
+def _force_status(env: _Env, file_id: str, status: str) -> None:
+    """Bypass the wire to plant a pre-existing state for state-machine tests."""
+    conn = sqlite3.connect(str(env.db_path))
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE files SET status = ? WHERE file_id = ?",
+                (status, file_id),
+            )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. Acceptance: Alice revokes her own pending upload → status flips to 'revoked'.
+# ---------------------------------------------------------------------------
+
+def test_happy_revoke_flips_status_to_revoked(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+        assert _row_status(env, file_id) == "pending"
+
+        with _session_socket(env, port, user="alice") as session:
+            ack = revoke_file(session, file_id)
+
+    assert ack["file_id"] == file_id
+    assert ack["status"] == "revoked"
+    assert _row_status(env, file_id) == "revoked"
+    # Per issue pitfall: blob must NOT be deleted by revoke.
+    assert (env.files / f"{file_id}.bin").is_file()
+
+
+# ---------------------------------------------------------------------------
+# 2. Acceptance: Bob tries to download afterwards → REVOKED error, no blob shipped.
+# ---------------------------------------------------------------------------
+
+def test_revoked_download_returns_revoked_with_no_blob_bytes(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+
+        # Alice revokes.
+        with _session_socket(env, port, user="alice") as session:
+            revoke_file(session, file_id)
+
+        # Bob tries to download.  Expect an ERROR/REVOKED envelope and
+        # absolutely no DOWNLOAD_RESPONSE / ciphertext on the wire.
+        with _session_socket(env, port, user="bob") as session:
+            send_message(
+                session["sock"],
+                make_envelope("DOWNLOAD_REQUEST", {"file_id": file_id}),
+            )
+            reply = validate_envelope(recv_message(session["sock"]))
+
+    assert reply["type"] == "ERROR"
+    assert reply["payload"]["code"] == "REVOKED"
+    # No download payload smuggled in.
+    assert "ciphertext" not in reply["payload"]
+    assert "wrapped_key" not in reply["payload"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Acceptance: Mallory tries to revoke Alice's file → NOT_AUTHORIZED.
+# ---------------------------------------------------------------------------
+
+def test_non_owner_revoke_is_not_authorized_and_row_unchanged(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+        assert _row_status(env, file_id) == "pending"
+
+        with _session_socket(env, port, user="mallory") as session:
+            with pytest.raises(ProtocolError) as exc_info:
+                revoke_file(session, file_id)
+
+    assert str(exc_info.value) == "NOT_AUTHORIZED"
+    assert _row_status(env, file_id) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# 4. Acceptance: Alice tries to revoke after Bob downloaded → ALREADY_DOWNLOADED.
+#    We simulate the post-download state by directly flipping the row, which is
+#    simpler than driving the full DOWNLOAD_ACK round-trip and exercises the
+#    state-machine branch the issue explicitly calls out.
+# ---------------------------------------------------------------------------
+
+def test_revoke_after_download_returns_already_downloaded(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+        _force_status(env, file_id, "downloaded")
+
+        with _session_socket(env, port, user="alice") as session:
+            with pytest.raises(ProtocolError) as exc_info:
+                revoke_file(session, file_id)
+
+    assert str(exc_info.value) == "ALREADY_DOWNLOADED"
+    assert _row_status(env, file_id) == "downloaded"
+
+
+# ---------------------------------------------------------------------------
+# 5. Acceptance: Alice revokes the same file twice → second call returns
+#    success (idempotent), no extra audit-INFO line.
+# ---------------------------------------------------------------------------
+
+def test_double_revoke_is_idempotent_success(env, caplog):
+    import logging
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+
+        with caplog.at_level(logging.INFO, logger="zerotrust"):
+            with _session_socket(env, port, user="alice") as session:
+                first = revoke_file(session, file_id)
+            # Second revoke — same file, same user.
+            with _session_socket(env, port, user="alice") as session:
+                second = revoke_file(session, file_id)
+
+    assert first["status"] == "revoked"
+    assert second["status"] == "revoked"
+    assert _row_status(env, file_id) == "revoked"
+
+    # "No log noise" acceptance bullet: exactly one INFO event=revoke_accept
+    # line — the second call must not emit another.
+    accept_lines = [
+        r for r in caplog.records
+        if r.levelno == logging.INFO and "event=revoke_accept" in r.message
+    ]
+    assert len(accept_lines) == 1, (
+        f"expected exactly one revoke_accept INFO, got {len(accept_lines)}:\n"
+        f"{caplog.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Acceptance: Revoke without a valid signature → AUTH_FAILED.
+#    We hand-build the envelope with a garbage signature so the canonical
+#    struct will not reconstruct.
+# ---------------------------------------------------------------------------
+
+def test_revoke_with_garbage_signature_is_auth_failed(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+
+        with _session_socket(env, port, user="alice") as session:
+            payload = {
+                "file_id": file_id,
+                "timestamp": int(time.time()),
+                "signature": _b64(b"\x00" * 256),  # garbage, wrong length even
+            }
+            send_message(
+                session["sock"], make_envelope("REVOKE_REQUEST", payload),
+            )
+            reply = validate_envelope(recv_message(session["sock"]))
+
+    assert reply["type"] == "ERROR"
+    assert reply["payload"]["code"] == "AUTH_FAILED"
+    assert _row_status(env, file_id) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# 7. Required test: forged signature (sign with a different key, present
+#    Alice's session cert) → AUTH_FAILED.  Mallory's key signs but the
+#    session cert is Alice's, so the verify against Alice's pubkey fails.
+# ---------------------------------------------------------------------------
+
+def test_revoke_forged_signature_yields_auth_failed(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+
+        with _session_socket(env, port, user="alice") as session:
+            ts = int(time.time())
+            # Sign claiming sender=alice but with mallory's private key —
+            # verify_revoke_struct will reconstruct against alice's pubkey
+            # (the session cert), which won't match.
+            forged = sign_revoke_struct(
+                env.mallory_priv, MALLORY_PASSWORD,
+                sender="alice", file_id=file_id, timestamp=ts,
+            )
+            payload = {
+                "file_id": file_id,
+                "timestamp": ts,
+                "signature": _b64(forged),
+            }
+            send_message(
+                session["sock"], make_envelope("REVOKE_REQUEST", payload),
+            )
+            reply = validate_envelope(recv_message(session["sock"]))
+
+    assert reply["type"] == "ERROR"
+    assert reply["payload"]["code"] == "AUTH_FAILED"
+    assert _row_status(env, file_id) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# 8. Required test: replay revoke envelope → STALE on the second send.
+# ---------------------------------------------------------------------------
+
+def test_replay_revoke_envelope_is_rejected(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+
+        with _session_socket(env, port, user="alice") as session:
+            ts = int(time.time())
+            sig = sign_revoke_struct(
+                env.alice_priv, ALICE_PASSWORD,
+                sender="alice", file_id=file_id, timestamp=ts,
+            )
+            payload = {
+                "file_id": file_id,
+                "timestamp": ts,
+                "signature": _b64(sig),
+            }
+            envelope = make_envelope("REVOKE_REQUEST", payload)
+
+            send_message(session["sock"], envelope)
+            first = validate_envelope(recv_message(session["sock"]))
+            assert first["type"] == "REVOKE_ACK"
+
+            # Same envelope again → STALE/REPLAY.
+            send_message(session["sock"], envelope)
+            second = validate_envelope(recv_message(session["sock"]))
+
+    assert second["type"] == "ERROR"
+    assert second["payload"]["code"] in {"STALE", "REPLAY"}
+    # Status doesn't regress.
+    assert _row_status(env, file_id) == "revoked"
+
+
+# ---------------------------------------------------------------------------
+# 9. Pitfall: payload['sender'] cannot override session['peer_subject'].
+#    Mallory connects (so the handshake-proven identity is mallory) and
+#    tries to revoke Alice's file by signing a struct that claims
+#    sender=alice.  The server rebuilds the canonical struct from the
+#    *session* identity, so the signature won't reconstruct, AND the
+#    ownership check would refuse anyway.  Either failure mode is
+#    acceptable; both result in the row staying pending.
+# ---------------------------------------------------------------------------
+
+def test_payload_sender_field_cannot_impersonate(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+
+        with _session_socket(env, port, user="mallory") as session:
+            ts = int(time.time())
+            # Sign a struct claiming sender=alice — mallory's session
+            # would re-derive canonical(sender=mallory, ...) so this
+            # signature won't verify even if we got past ownership.
+            sig = sign_revoke_struct(
+                env.mallory_priv, MALLORY_PASSWORD,
+                sender="alice", file_id=file_id, timestamp=ts,
+            )
+            payload = {
+                "file_id": file_id,
+                "timestamp": ts,
+                "signature": _b64(sig),
+            }
+            send_message(
+                session["sock"], make_envelope("REVOKE_REQUEST", payload),
+            )
+            reply = validate_envelope(recv_message(session["sock"]))
+
+    assert reply["type"] == "ERROR"
+    # Ownership check fires before signature verify, so the wire code is
+    # NOT_AUTHORIZED.  That's the desired outcome — it proves we never
+    # honoured a payload-side sender claim.
+    assert reply["payload"]["code"] == "NOT_AUTHORIZED"
+    assert _row_status(env, file_id) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# 10. Pitfall: revoke must not delete the ciphertext blob.
+#     The cleanup thread (issue #27) is the only thing allowed to touch
+#     the filesystem; revoke just flips the status.
+# ---------------------------------------------------------------------------
+
+def test_revoke_does_not_delete_blob(env):
+    with _running_server(env) as port:
+        file_id = _upload_one(env, port)
+        blob_path = env.files / f"{file_id}.bin"
+        assert blob_path.is_file()
+
+        with _session_socket(env, port, user="alice") as session:
+            revoke_file(session, file_id)
+
+    # Blob must still be there after revoke.
+    assert blob_path.is_file()
+    assert _row_status(env, file_id) == "revoked"
+
+
+# ---------------------------------------------------------------------------
+# 11. NOT_FOUND: revoking a file_id the server has never seen.
+# ---------------------------------------------------------------------------
+
+def test_revoke_unknown_file_id_yields_not_found(env):
+    with _running_server(env) as port:
+        with _session_socket(env, port, user="alice") as session:
+            with pytest.raises(ProtocolError) as exc_info:
+                revoke_file(session, str(uuid.uuid4()))
+
+    assert str(exc_info.value) == "NOT_FOUND"


### PR DESCRIPTION
Issue #24 / milestone-3 (bonus).

Lets the sender recall a still-pending upload before the recipient downloads it. Adds a signed REVOKE_REQUEST message; the server verifies ownership + per-request signature, flips the row to status='revoked', and subsequent download attempts get REVOKED. The ciphertext blob is deliberately left on disk — cleanup is the cleanup thread's job (#27), per issue pitfall.

zerotrust/common/revoke.py (NEW)
  - sign_revoke_struct / verify_revoke_struct over the frozen canonical struct {action:'revoke', file_id, sender, timestamp}. action field domain-separates revoke from future signed envelopes; keyword-only args prevent positional sender/file_id swap.

zerotrust/common/protocol.py
  - REVOKE_ACK added to MESSAGE_TYPES (REVOKE_REQUEST was already present).

zerotrust/server/handler.py
  - New _handle_revoke_request dispatch case implementing the 7-step flow from the issue body: 1. Envelope replay/freshness (same primitive as upload) 2. File lookup → NOT_FOUND if missing 3. Ownership: session['peer_subject'] == row['sender_id'] (NEVER payload['sender'] — first issue pitfall) → NOT_AUTHORIZED 4. Cert re-verify + RSA-PSS revoke struct verify → AUTH_FAILED (signature is checked even though session is authenticated — issue pitfall about 'we already authenticated') 5. State machine: pending→revoked; downloaded→ALREADY_DOWNLOADED; expired→EXPIRED; revoked→idempotent REVOKE_ACK (logged at DEBUG, no INFO noise per 'no log noise' acceptance bullet) 6. store.mark_status(conn, file_id, 'revoked') — never roll our own UPDATE (issue pitfall) 7. REVOKE_ACK {file_id, status}
  - Structured audit events: INFO event=revoke_accept (with sender_fp), WARNING event=revoke_reject / unauthorized_revoke / replay_reject, ERROR event=revoke_sig_fail / revoke_internal_error. Existing Forbidden-list audit isolation guarantees still hold.
  - DOWNLOAD path already returns REVOKED for status=='revoked' (handled by _authorise_download); revocation just flips the row.

zerotrust/client/revoke.py (NEW)
  - revoke_file(session, file_id) builds + sends the signed REVOKE_REQUEST and returns the REVOKE_ACK payload. Uses sign_revoke_struct — never an inline json.dumps (issue pitfall).

zerotrust/client/cli.py
  - New 'revoke <file_id>' subcommand mirroring the upload/download error-handling shape. Exits 0 on REVOKE_ACK (including idempotent second revoke); non-zero with the server's error code otherwise.

zerotrust/tests/test_revocation.py (NEW, 11 tests)
  Acceptance criteria from the issue:
    * happy revoke → row flips to 'revoked', blob NOT deleted
    * post-revoke download → REVOKED, no ciphertext in response payload
    * non-owner (mallory) → NOT_AUTHORIZED, row unchanged
    * post-download → ALREADY_DOWNLOADED, row stays 'downloaded'
    * double revoke → idempotent success, exactly one INFO event=revoke_accept (no log noise)
    * garbage signature → AUTH_FAILED, row unchanged Required tests from the issue:
    * forged signature (mallory's key, alice's session) → AUTH_FAILED
    * replay revoke envelope → STALE on the second send Pitfall regressions:
    * payload['sender'] cannot impersonate (mallory session, claims alice in canonical struct → NOT_AUTHORIZED before sig check)
    * revoke must not delete the on-disk ciphertext blob Plus NOT_FOUND for unknown file_ids.

248 tests pass; ruff clean.